### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want to see it in action? Download the example and feel free to enable the DEBUG
 
 # Installation
 
-**If you use Cocoapods, the feel free to add the following to your podfile:**
+**If you use CocoaPods, the feel free to add the following to your podfile:**
 
 ```
 pod 'SQLFetchedResultsController'
@@ -28,7 +28,7 @@ pod 'SQLFetchedResultsController'
 # pod 'SQLFetchedResultsController', '~> X.X.X'
 ```
 
-**If you do not use Cocoapods, do the following:**
+**If you do not use CocoaPods, do the following:**
 
 1. Add the files within Src/ to your project
 2. Grab the latest FMDB version from: https://github.com/ccgus/fmdb


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
